### PR TITLE
Axis conversion code

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,12 +35,17 @@ else:
     from bpy.props import *
     from bpy_extras.io_utils import (
             ExportHelper,
+            orientation_helper_factory,
+            axis_conversion
             )
 
     from . import blendergltf
 
+    GLTFOrientationHelper = orientation_helper_factory(
+        "GLTFOrientationHelper", axis_forward='-Z', axis_up='Y'
+    )
 
-    class ExportGLTF(bpy.types.Operator, ExportHelper):
+    class ExportGLTF(bpy.types.Operator, ExportHelper, GLTFOrientationHelper):
         """Save a Khronos glTF File"""
 
         bl_idname = "export_scene.gltf"
@@ -80,6 +85,12 @@ else:
 
             # Copy properties to settings
             settings = self.as_keywords(ignore=("filter_glob",))
+
+            # Calculate a global matrix to apply to each mesh.
+            settings['global_matrix'] = axis_conversion(
+                to_forward=self.axis_forward,
+                to_up=self.axis_up
+            ).to_4x4()
 
             gltf = blendergltf.export_gltf(scene, settings)
             with open(self.filepath, 'w') as fout:

--- a/__init__.py
+++ b/__init__.py
@@ -56,24 +56,26 @@ else:
 
         #blendergltf settings
         materials_export_shader = BoolProperty(name='Export Shaders', default=False)
+        meshes_apply_modifiers = BoolProperty(name='Apply Modifiers', default=True)
         images_embed_data = BoolProperty(name='Embed Image Data', default=False)
 
         def execute(self, context):
             scene = {
-                'actions': bpy.data.actions,
-                'camera': bpy.data.cameras,
-                'lamps': bpy.data.lamps,
-                'images': bpy.data.images,
-                'materials': bpy.data.materials,
-                'meshes': bpy.data.meshes,
-                'objects': bpy.data.objects,
-                'scenes': bpy.data.scenes,
-                'textures': bpy.data.textures,
+                'actions': list(bpy.data.actions),
+                'camera': list(bpy.data.cameras),
+                'lamps': list(bpy.data.lamps),
+                'images': list(bpy.data.images),
+                'materials': list(bpy.data.materials),
+                'meshes': list(bpy.data.meshes),
+                'objects': list(bpy.data.objects),
+                'scenes': list(bpy.data.scenes),
+                'textures': list(bpy.data.textures),
             }
             # Copy properties to settings
             settings = blendergltf.default_settings.copy()
             settings['materials_export_shader'] = self.materials_export_shader
             settings['images_embed_data'] = self.images_embed_data
+            settings['meshes_apply_modifiers'] = self.meshes_apply_modifiers
 
             gltf = blendergltf.export_gltf(scene, settings)
             with open(self.filepath, 'w') as fout:

--- a/__init__.py
+++ b/__init__.py
@@ -84,7 +84,8 @@ else:
             }
 
             # Copy properties to settings
-            settings = self.as_keywords(ignore=("filter_glob",))
+            settings = self.as_keywords(ignore=("filter_glob", "axis_up",
+                                                "axis_forward"))
 
             # Calculate a global matrix to apply to each mesh.
             settings['global_matrix'] = axis_conversion(

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -13,6 +13,7 @@ default_settings = {
     'materials_export_shader': False,
     'meshes_apply_modifiers': True,
     'images_embed_data': False,
+    'global_matrix': mathutils.Matrix.Identity(4)
 }
 
 

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -883,6 +883,8 @@ def export_gltf(scene_delta, settings={}):
     if global_matrix != None:
         # If a global matrix was provided apply it to all objects.
         for obj in object_list:
+            if obj.type != 'MESH': continue
+
             # Find the mesh associated with this object
             if obj.name in mod_meshes:
                 # Use the modified mesh copy (completely safe to modify).

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -11,6 +11,7 @@ import struct
 
 default_settings = {
     'materials_export_shader': False,
+    'meshes_apply_modifiers': True,
     'images_embed_data': False,
 }
 
@@ -478,7 +479,7 @@ def export_meshes(meshes, skinned_meshes):
             g_buffers.append(skin_buf)
         return gltf_mesh
 
-    return {me.name: export_mesh(me) for me in meshes if me.users != 0}
+    return {me.name: export_mesh(me) for me in meshes}
 
 
 def export_skins(skinned_meshes):
@@ -569,7 +570,7 @@ def export_lights(lamps):
     return gltf
 
 
-def export_nodes(objects, skinned_meshes):
+def export_nodes(objects, skinned_meshes, modded_meshes):
     def export_physics(obj):
         rb = obj.rigid_body
         physics =  {
@@ -592,10 +593,11 @@ def export_nodes(objects, skinned_meshes):
         }
 
         if obj.type == 'MESH':
-            ob['meshes'] = [obj.data.name]
+            mesh = modded_meshes.get(obj.name, obj.data)
+            ob['meshes'] = [mesh.name]
             if obj.find_armature():
                 ob['skeletons'] = ['{}_root'.format(obj.find_armature().data.name)]
-                skinned_meshes[obj.data.name] = obj
+                skinned_meshes[mesh.name] = obj
         elif obj.type == 'LAMP':
             ob['extras'] = {'light': obj.data.name}
         elif obj.type == 'CAMERA':
@@ -849,7 +851,28 @@ def export_gltf(scene_delta, settings={}):
     shaders = {}
     programs = {}
     techniques = {}
+    mesh_list = []
+    mod_meshes = {}
     skinned_meshes = {}
+    object_list = list(scene_delta.get('objects', []))
+
+    # Apply modifiers
+    if settings['meshes_apply_modifiers']:
+        scene = bpy.context.scene
+        mod_obs = [ob for ob in object_list if ob.is_modified(scene, 'PREVIEW')]
+        for mesh in scene_delta.get('meshes', []):
+            mod_users = [ob for ob in mod_obs if ob.data == mesh]
+
+            # Only convert meshes with modifiers, otherwise each non-modifier
+            # user ends up with a copy of the mesh and we lose instancing
+            mod_meshes.update({ob.name: ob.to_mesh(scene, True, 'PREVIEW') for ob in mod_users})
+
+            # Add unmodified meshes directly to the mesh list
+            if len(mod_users) < mesh.users:
+                mesh_list.append(mesh)
+        mesh_list.extend(mod_meshes.values())
+    else:
+        mesh_list = scene_delta.get('meshes', [])
 
     gltf = {
         'asset': {'version': '1.0'},
@@ -861,9 +884,9 @@ def export_gltf(scene_delta, settings={}):
         'images': export_images(settings, scene_delta.get('images', [])),
         'materials': export_materials(settings, scene_delta.get('materials', []),
             shaders, programs, techniques),
-        'nodes': export_nodes(scene_delta.get('objects', []), skinned_meshes),
+        'nodes': export_nodes(object_list, skinned_meshes, mod_meshes),
         # Make sure meshes come after nodes to detect which meshes are skinned
-        'meshes': export_meshes(scene_delta.get('meshes', []), skinned_meshes),
+        'meshes': export_meshes(mesh_list, skinned_meshes),
         'skins': export_skins(skinned_meshes),
         'programs': programs,
         'samplers': {'default':{}},
@@ -885,5 +908,9 @@ def export_gltf(scene_delta, settings={}):
     g_buffers = []
 
     gltf = {key: value for key, value in gltf.items() if value}
+
+    # Remove any temporary meshes from applying modifiers
+    for mesh in mod_meshes.values():
+        bpy.data.meshes.remove(mesh)
 
     return gltf

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -591,7 +591,7 @@ def export_meshes(meshes, skinned_meshes, mesh_names):
     for me in meshes:
         gltf_mesh = export_mesh(me)
         if gltf_mesh != None:
-            exported_meshes.update({me.name: gltf_mesh})
+            exported_meshes.update({mesh_names[me.name]: gltf_mesh})
     return exported_meshes
 
 def export_skins(skinned_meshes):

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -549,7 +549,9 @@ def export_meshes(meshes, skinned_meshes, mesh_names):
 
         if max_vert_index > 65535:
             # Mesh too big!
-            print(("Too many vertices ({}) in mesh {}").format(max_vert_index, me.name))
+            print(("Too many vertices ({}) in mesh {}").format(
+                max_vert_index, mesh_names[me.name]
+            ))
             return None
 
         for mat, prim in prims.items():


### PR DESCRIPTION
I realized implementing this without taking into account the modifier code wouldn't be very useful when it came time to merge, so I decided to merge with apply_modifiers before writing it.

I wasn't sure where exactly the global / axis conversion matrix should be generated (`__init__.py` vs `blendergltf.py`) so I opted to generate the global matrix in `__init__.py` and use it in `export_gltf`. My thinking was that we can apply any number of additional transformations in the future based on export options (a conversion between units, for example).

Instead of duplicating unmodified meshes, I decided to transform them with the global matrix, then mark them to be reverted back to the correct space before finishing up. This works fine for the most part, but I realize could cause problems if the script were to crash. One of the reasons I implemented integer indices in the first place was because it was a quick solution to a crash that would occur when python refused to pack a large number into a short.

Let me know if you think I ought to duplicate every mesh before doing the transformation and I'll change it.

I was also planning on adding some code to properly detect large meshes and refuse to export them gracefully, do you think it would be better if I keep this PR as is and then handle the 16-bit integer overflow crash specifically?
