### PR TITLE
Mesh changes

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -371,6 +371,37 @@ def export_materials(settings, materials, shaders, programs, techniques):
 
 
 def export_meshes(meshes, skinned_meshes):
+    def triangulate(indices):
+
+        # Triangulate each polygon if necessary
+        if len(indices) == 3:
+            # No triangulation necessary
+            return indices
+        elif len(indices) > 3:
+            # Triangulation necessary
+            total_indices = []
+            for i in range(len(indices) - 2):
+                total_indices += (indices[-1], indices[i], indices[i + 1])
+            return total_indices
+        else:
+            # Bad polygon, probably an edge or something strange.
+            raise RuntimeError(
+                "Invalid polygon with {} vertices.".format(len(indices))
+            )
+
+    def get_index_type_stride(max_index):
+        if max_index > 65535:
+            # Too large! In the future we may want to just split the mesh into
+            # smaller parts.
+            raise RuntimeError(
+                "Mesh is too large with {} vertices.".format(max_index)
+            )
+
+        # Otherwise the mesh will fit in a short just fine.
+        itype = Buffer.UNSIGNED_SHORT
+        istride = 2
+        return itype, istride
+
     def export_mesh(me):
         # glTF data
         gltf_mesh = {
@@ -458,20 +489,15 @@ def export_meshes(meshes, skinned_meshes):
                 if i > max_vert_index:
                     max_vert_index = i
 
-            # Triangulate each polygon if necessary
-            if poly.loop_total == 3:
-                prim += indices
-            elif poly.loop_total > 3:
-                for i in range(poly.loop_total-2):
-                    prim += (indices[-1], indices[i], indices[i + 1])
-            else:
-                raise RuntimeError(("Invalid polygon with {} "
-                                    "vertices.").format(poly.loop_total))
+            prim += triangulate(indices)
 
         for mat, prim in prims.items():
             # For each primitive set add an index buffer and accessor.
-            ib = buf.add_view(2 * len(prim), Buffer.ELEMENT_ARRAY_BUFFER)
-            idata = buf.add_accessor(ib, 0, 2, Buffer.UNSIGNED_SHORT, len(prim),
+
+            itype, istride = get_index_type_stride(max_vert_index)
+
+            ib = buf.add_view(istride * len(prim), Buffer.ELEMENT_ARRAY_BUFFER)
+            idata = buf.add_accessor(ib, 0, istride, itype, len(prim),
                                      Buffer.SCALAR)
 
             for i, v in enumerate(prim):

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -453,8 +453,7 @@ def export_meshes(meshes, skinned_meshes):
 
             # Used to determine whether a mesh must be split.
             for i in indices:
-                if i > max_vert_index:
-                    max_vert_index = i
+                max_vert_index = max(i, max_vert_index)
 
             if len(indices) == 3:
                 # No triangulation necessary


### PR DESCRIPTION
Cleans up / comments the code in `export_meshes`.

The max index is recorded so that in the future we'll have means to determine whether the mesh needs to be split. The code will currently print a warning when it can't fit the mesh in shorts, which is more user-friendly than the error thrown by `struct.pack_into`.
