### PR TITLE
Remove loop in export_mesh when finding max index

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -452,8 +452,7 @@ def export_meshes(meshes, skinned_meshes):
             indices = [vert_dict[i].index for i in poly.loop_indices]
 
             # Used to determine whether a mesh must be split.
-            for i in indices:
-                max_vert_index = max(i, max_vert_index)
+            max_vert_index = max(max_vert_index, max(indices))
 
             if len(indices) == 3:
                 # No triangulation necessary


### PR DESCRIPTION
The max function can be used on lists directly (thanks onox).
