### PR TITLE
Only add primitive.material if not empty

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -579,7 +579,7 @@ def export_meshes(settings, meshes, skinned_meshes):
             for i, v in enumerate(prim):
                 idata[i] = v
 
-            assert len(idata.name) >= 1
+            assert len(idata.name) >= 1, "Mesh '{}' has primitive with no indices".format(me.name)
             gltf_prim = {
                 'attributes': {
                     'POSITION': vdata.name,

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -579,6 +579,7 @@ def export_meshes(settings, meshes, skinned_meshes):
             for i, v in enumerate(prim):
                 idata[i] = v
 
+            assert len(idata.name) >= 1
             gltf_prim = {
                 'attributes': {
                     'POSITION': vdata.name,
@@ -586,8 +587,9 @@ def export_meshes(settings, meshes, skinned_meshes):
                 },
                 'indices': idata.name,
                 'mode': 4,
-                'material': mat,
             }
+            if len(mat) >= 1:
+                gltf_prim['material'] = mat
             for i, v in enumerate(tdata):
                 gltf_prim['attributes']['TEXCOORD_' + me.uv_layers[i].name] = v.name
 


### PR DESCRIPTION
If the material / texture of an object is messed up in Blender, material
ID can be empty. But if "material" is defined, it must not be empty.

Fixes #23 
