### PR TITLE
Add assert statement for accessor.count

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -143,7 +143,7 @@ class Buffer:
                      component_type,
                      count,
                      type):
-            assert count >= 1
+            assert count >= 1, "Accessor '{}' has no count >= 1".format(name)
             self.name = name
             self.buffer = buffer
             self.buffer_view = buffer_view

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -564,6 +564,10 @@ def export_meshes(settings, meshes, skinned_meshes):
         for mat, prim in prims.items():
             # For each primitive set add an index buffer and accessor.
 
+            # Do not add primitves with no indices
+            if not len(prim):
+                continue
+
             # If we got this far use integers if we have to, if this is not
             # desirable we would have bailed out by now.
             if max_vert_index > 65535:

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -143,6 +143,7 @@ class Buffer:
                      component_type,
                      count,
                      type):
+            assert count >= 1
             self.name = name
             self.buffer = buffer
             self.buffer_view = buffer_view


### PR DESCRIPTION
If the material / texture of an object is messed up in Blender, a mesh
can contain a primitive that has an "indices" member that points to an
accessor that has a "count" value that is 0.

"count" must be >= 1. See accessor.count in the glTF spec.

Fixes #24 
