### PR TITLE
Export material and scene names

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -403,7 +403,8 @@ def export_materials(settings, materials, shaders, programs, techniques):
                             'transparent': material.use_transparency,
                         }
                     }
-                }
+                },
+                'name': material.name,
             }
     exp_materials = {}
     for material in materials:
@@ -846,6 +847,7 @@ def export_scenes(settings, scenes):
                 'background_color': scene.world.horizon_color[:],
                 'active_camera': scene.camera.name if scene.camera else '',
                 'frames_per_second': scene.render.fps,
+                'name': scene.name,
             }
         }
 

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -847,8 +847,8 @@ def export_scenes(settings, scenes):
                 'background_color': scene.world.horizon_color[:],
                 'active_camera': scene.camera.name if scene.camera else '',
                 'frames_per_second': scene.render.fps,
-                'name': scene.name,
-            }
+            },
+            'name': scene.name,
         }
 
         if settings['nodes_export_hidden']:


### PR DESCRIPTION
The id and name are the same for these, but after importing into three.js the id is gone. The name will be assigned to the objects, which is useful for debugging.