### PR TITLE
Support output of smoothed normals

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -131,20 +131,26 @@ class SmartVertexList:
     '''
 
     def __init__(self):
-        self.data = []
-        self.hashes = []
+        self.data = {}
+        self.hashes = set()
 
     def add(self, mesh, loop):
         test_vert = Vertex(mesh, loop)
         h = test_vert.__hash__()
 
         if h in self.hashes:
-            vert = self.data[self.data.index(test_vert)]
+            vert = self.data[h]
             vert.loop_indices.append(loop.index)
         else:
-            test_vert.index = len(self.data)
-            self.data.append(test_vert)
-            self.hashes.append(h)
+            test_vert.index = len(self.hashes)
+            self.data[h] = test_vert
+            self.hashes.add(h)
+
+    def get_list(self):
+        vertlist = list(self.data.values())
+        vertlist.sort(key=lambda v: v.index)
+        return vertlist
+
 
 class Buffer:
     ARRAY_BUFFER = 34962
@@ -581,7 +587,7 @@ def export_meshes(settings, meshes, skinned_meshes):
         vert_list = SmartVertexList()
         for loop in me.loops:
             vert_list.add(me, loop)
-        vert_list = vert_list.data
+        vert_list = vert_list.get_list()
         num_verts = len(vert_list)
         va = buf.add_view(vertex_size * num_verts, Buffer.ARRAY_BUFFER)
 

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -132,15 +132,19 @@ class SmartVertexList:
 
     def __init__(self):
         self.data = []
+        self.hashes = []
 
     def add(self, mesh, loop):
         test_vert = Vertex(mesh, loop)
-        if test_vert in self.data:
+        h = test_vert.__hash__()
+
+        if h in self.hashes:
             vert = self.data[self.data.index(test_vert)]
             vert.loop_indices.append(loop.index)
         else:
             test_vert.index = len(self.data)
             self.data.append(test_vert)
+            self.hashes.append(h)
 
 class Buffer:
     ARRAY_BUFFER = 34962

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -71,7 +71,7 @@ class Vertex:
 
         # populate vert info from mesh data
         self.co = mesh.vertices[vi].co.freeze()
-        if __use_smooth_normal(mesh, loop):
+        if Vertex.__use_smooth_normal(mesh, loop):
             self.normal = mesh.vertices[vi].normal.freeze()
         else:
             self.normal = loop.normal.freeze()
@@ -137,10 +137,10 @@ class SmartVertexList:
         test_vert = Vertex(mesh, loop)
         if test_vert in self.data:
             vert = self.data[self.data.index(test_vert)]
-            vert.loop_indices.push(loop.index)
+            vert.loop_indices.append(loop.index)
         else:
             test_vert.index = len(self.data)
-            self.data.push(test_vert)
+            self.data.append(test_vert)
 
 class Buffer:
     ARRAY_BUFFER = 34962

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -54,7 +54,6 @@ else:
     from . import gpu_luts
     from . import shader_converter
 
-
 class Vertex:
     __slots__ = (
         "co",
@@ -65,6 +64,7 @@ class Vertex:
         "weights",
         "joint_indexes",
         )
+
     def __init__(self, mesh, loop):
         vi = loop.vertex_index
         i = loop.index
@@ -93,6 +93,7 @@ class Vertex:
 
         self.index = 0
 
+    poly_lookup = {}
     @staticmethod
     def __use_smooth_normal(mesh, loop):
         '''
@@ -100,10 +101,15 @@ class Vertex:
         :rtype: Boolean
         '''
 
-        autosmooth = mesh.use_auto_smooth
-        edge_is_sharp = mesh.edges[loop.edge_index].use_edge_sharp
+        def get_poly_for_loop(mesh, loop):
+            ''' Helper function to look up and cache polygons '''
+            if mesh not in Vertex.poly_lookup:
+                Vertex.poly_lookup[mesh] = {i: p for p in mesh.polygons for i in p.loop_indices}
+            return Vertex.poly_lookup[mesh][loop.index]
 
-        return autosmooth and not edge_is_sharp
+        face = get_poly_for_loop(mesh, loop)
+
+        return face.use_smooth
 
 
     def __hash__(self):


### PR DESCRIPTION
I've made two main changes. First, a given output vertex uses the mesh vertex normal if both `mesh.use_auto_smooth` is enabled, and the edge it's a part of is not marked as a "sharp" edge. Otherwise, the vertex will use the loop normal (the current output). Second, I have changed the way vertices are indexed. Previously, vertices stored a loop index array, but there was no way to update that array if a duplicate ever came up. Now, the SmartVertexList can look up the matching vertex.

This PR works, but it's *super* slow. Takes several minutes to output an isosphere with 10k vertices. Still trying to improve that run time, but I wanted to get more eyes on this first. Thoughts?