### PR TITLE
Add option to dump geometry data to separate file

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,6 +74,7 @@ else:
         meshes_apply_modifiers = BoolProperty(name='Apply Modifiers', default=True)
         meshes_interleave_vertex_data = BoolProperty(name='Interleave Vertex Data', default=True)
         images_embed_data = BoolProperty(name='Embed Image Data', default=False)
+        geo_embed_data = BoolProperty(name='Embed Binary Geometry', default=True)
         asset_profile = EnumProperty(items=profile_items, name='Profile', default='WEB')
         ext_export_physics = BoolProperty(name='Export Physics Settings', default=False)
         ext_export_actions = BoolProperty(name='Export Actions', default=False)

--- a/__init__.py
+++ b/__init__.py
@@ -30,7 +30,6 @@ else:
 
 
     import json
-
     import bpy
     from bpy.props import *
     from bpy_extras.io_utils import (
@@ -74,7 +73,7 @@ else:
         meshes_apply_modifiers = BoolProperty(name='Apply Modifiers', default=True)
         meshes_interleave_vertex_data = BoolProperty(name='Interleave Vertex Data', default=True)
         images_embed_data = BoolProperty(name='Embed Image Data', default=False)
-        geo_embed_data = BoolProperty(name='Embed Binary Geometry', default=True)
+        geo_embed_data = BoolProperty(name='Embed Geometry Data', default=True)
         asset_profile = EnumProperty(items=profile_items, name='Profile', default='WEB')
         ext_export_physics = BoolProperty(name='Export Physics Settings', default=False)
         ext_export_actions = BoolProperty(name='Export Actions', default=False)
@@ -111,7 +110,9 @@ else:
                 to_up=self.axis_up
             ).to_4x4()
 
-            gltf = blendergltf.export_gltf(scene, settings)
+            settings['filepath'] = self.filepath
+
+            gltf, data_bin = blendergltf.export_gltf(scene, settings)
             with open(self.filepath, 'w') as fout:
                 # Figure out indentation
                 if self.pretty_print:
@@ -126,6 +127,13 @@ else:
                 if self.pretty_print:
                     # Write a newline to the end of the file
                     fout.write('\n')
+
+            # output geometry data
+            if not settings['geo_embed_data']:
+                bin_filename = self.filepath[:-5] + '.bin'
+                with open(bin_filename, 'wb', buffering=0) as fout:
+                    fout.write(data_bin)
+
             return {'FINISHED'}
 
 

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -18,9 +18,10 @@ default_settings = {
     'meshes_apply_modifiers': True,
     'meshes_interleave_vertex_data' : True,
     'images_embed_data': False,
+    'geo_embed_data': True,
     'asset_profile': 'WEB',
     'ext_export_physics': False,
-    'ext_export_actions': False,
+    'ext_export_actions': False
 }
 
 
@@ -235,7 +236,7 @@ class Buffer:
         self.buffer_views = collections.OrderedDict()
         self.accessors = {}
 
-    def export_buffer(self):
+    def export_buffer(self, settings):
         data = bytearray()
         for bn, bv in self.buffer_views.items():
             data.extend(bv['data'])
@@ -877,7 +878,7 @@ def export_scenes(settings, scenes):
     return {scene.name: export_scene(scene) for scene in scenes}
 
 
-def export_buffers():
+def export_buffers(settings):
     gltf = {
         'buffers': {},
         'bufferViews': {},
@@ -885,7 +886,7 @@ def export_buffers():
     }
 
     buf = g_buffer, data = None
-    gltf['buffers'][buf.name], data = buf.export_buffer()
+    gltf['buffers'][buf.name], data = buf.export_buffer(settings)
     gltf['bufferViews'].update(buf.export_views())
     gltf['accessors'].update(buf.export_accessors())
 
@@ -1184,7 +1185,7 @@ def export_gltf(scene_delta, settings={}):
     if settings['nodes_global_matrix'] != mathutils.Matrix.Identity(4):
         insert_root_nodes(gltf, togl(settings['nodes_global_matrix']))
 
-    data, data_bin = export_buffers()
+    data, data_bin = export_buffers(settings)
     gltf.update(data)
     gltf.update({'glExtensionsUsed': g_glExtensionsUsed})
     g_buffer = None


### PR DESCRIPTION
This PR causes all the mesh buffers to be merged into one, and dumped to a binary file if the export option is set.

It doesn't work yet, so don't merge it, but all the fundamentals are in place. I think the buffer pointers are being corrupted somewhere, the output is just garbage. Do you see any problems?