### PR TITLE
Packed image texture support

### DIFF
--- a/blendergltf.py
+++ b/blendergltf.py
@@ -962,7 +962,7 @@ def export_images(settings, images):
         if image.type != 'IMAGE':
             errors.append('not an image')
 
-        if len(errors) > 0:
+        if errors:
             err_list = '\n\t'.join(errors)
             print('Unable to export image {} due to the following errors:\n\t{}'.format(image.name, err_list))
             return False
@@ -976,7 +976,7 @@ def export_images(settings, images):
         storage_setting = settings['images_data_storage']
         image_packed = image.packed_file != None
         if image_packed and storage_setting in ['COPY','REFERENCE']:
-            if image.file_format in extMap and False:
+            if image.file_format in extMap:
                 # save the file to the output directory
                 uri = '.'.join([image.name, extMap[image.file_format]])
                 temp = image.filepath
@@ -1019,7 +1019,7 @@ def export_textures(textures):
         else if texture.image.channels not in [3,4]:
             errors.append('points to {}-channel image (must be 3 or 4)'.format(texture.image.channels))
 
-        if len(errors) > 0:
+        if errors:
             err_list = '\n\t'.join(errors)
             print('Unable to export texture {} due to the following errors:\n\t{}'.format(texture.name, err_list))
             return False

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -953,11 +953,11 @@ def export_images(settings, images):
     def check_image(image):
         errors = []
         if image.size[0] == 0:
-            errors.add('x dimension is 0')
+            errors.append('x dimension is 0')
         if image.size[1] == 0:
-            errors.add('y dimension is 0')
+            errors.append('y dimension is 0')
 
-        if errors:
+        if len(errors) > 0:
             err_list = '\n\t'.join(errors)
             print('Unable to export image {} due to the following errors:\n\t{}'.format(image.name, err_list))
             return False

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -924,7 +924,7 @@ def export_buffers(settings):
     return gltf
 
 
-def image_to_data_uri(image):
+def image_to_data_uri(image, bytes=False):
     width = image.size[0]
     height = image.size[1]
     buf = bytearray([int(p * 255) for p in image.pixels])
@@ -946,7 +946,10 @@ def image_to_data_uri(image):
         png_pack(b'IDAT', zlib.compress(raw_data, 9)),
         png_pack(b'IEND', b'')])
 
-    return 'data:image/png;base64,' + base64.b64encode(png_bytes).decode()
+    if bytes:
+        return png_bytes
+    else:
+        return 'data:image/png;base64,' + base64.b64encode(png_bytes).decode()
 
 
 def export_images(settings, images):
@@ -983,8 +986,7 @@ def export_images(settings, images):
             else:
                 # convert to png and save
                 uri = '.'.join([image.name, 'png'])
-                data_uri = image_to_data_uri(image)
-                png = base64.b64decode(data_uri[22:])
+                png = image_to_data_uri(image, bytes=True)
                 with open( os.path.join(settings['gltf_output_dir'], uri), 'wb' ) as outfile:
                     outfile.write(png)
 

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -968,7 +968,11 @@ def export_images(settings, images):
         uri = ''
 
         storage_setting = settings['images_data_storage']
-        if storage_setting == 'COPY':
+        image_packed = image.packed_file != None
+        if image_packed and storage_setting in ['COPY','REFERENCE']:
+            # TODO: output packed image to appropriate location
+            pass
+        elif storage_setting == 'COPY':
             try:
                 shutil.copy(bpy.path.abspath(image.filepath), settings['gltf_output_dir'])
             except shutil.SameFileError:


### PR DESCRIPTION
If the output mode is Copy or Reference, packed textures will be saved to a file in the output directory, and URIs will point at it. Embed mode is unchanged.

Also added better general error handling for edge cases in images/textures.