### PR TITLE
Bug/misc fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,9 +129,6 @@ else:
                 to_up=self.axis_up
             ).to_4x4()
 
-            # apply exporter-only texture settings
-            settings['images_allow_srgb'] = False
-
             gltf = blendergltf.export_gltf(scene, settings)
             with open(self.filepath, 'w') as fout:
                 # Figure out indentation

--- a/__init__.py
+++ b/__init__.py
@@ -128,6 +128,9 @@ else:
                 to_up=self.axis_up
             ).to_4x4()
 
+            # apply exporter-only texture settings
+            settings['images_allow_srgb'] = False
+
             gltf = blendergltf.export_gltf(scene, settings)
             with open(self.filepath, 'w') as fout:
                 # Figure out indentation

--- a/__init__.py
+++ b/__init__.py
@@ -89,6 +89,7 @@ else:
         meshes_apply_modifiers = BoolProperty(name='Apply Modifiers', default=True)
         meshes_interleave_vertex_data = BoolProperty(name='Interleave Vertex Data', default=True)
         images_data_storage = EnumProperty(items=image_storage_items, name='Image Storage', default='COPY')
+        images_allow_srgb = BoolProperty(name='sRGB Texture Support', default=False)
         asset_profile = EnumProperty(items=profile_items, name='Profile', default='WEB')
         ext_export_physics = BoolProperty(name='Export Physics Settings', default=False)
         ext_export_actions = BoolProperty(name='Export Actions', default=False)

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -27,7 +27,7 @@ default_settings = {
     'asset_profile': 'WEB',
     'ext_export_physics': False,
     'ext_export_actions': False,
-    'images_allow_srgb': True
+    'images_allow_srgb': False
 }
 
 
@@ -713,7 +713,6 @@ def export_meshes(settings, meshes, skinned_meshes):
 
     exported_meshes = {}
     for me in meshes:
-        #if me.users != 0:
         gltf_mesh = export_mesh(me)
         if gltf_mesh != None:
             exported_meshes.update({'mesh_' + me.name: gltf_mesh})
@@ -1014,7 +1013,7 @@ def export_images(settings, images):
     return {'image_' + image.name: export_image(image) for image in images if check_image(image)}
 
 
-def export_textures(textures, images_allow_srgb):
+def export_textures(textures, settings):
     def check_texture(texture):
         errors = []
         if texture.image == None:
@@ -1032,11 +1031,11 @@ def export_textures(textures, images_allow_srgb):
     def export_texture(texture):
         gltf_texture = {
             'sampler' : 'sampler_default',
-            'source' : 'image_' + texture.image.name
+            'source' : 'image_' + texture.image.name,
         }
         tformat = None
         channels = texture.image.channels
-        use_srgb = images_allow_srgb and texture.image.colorspace_settings.name == 'sRGB'
+        use_srgb = settings['images_allow_srgb'] and texture.image.colorspace_settings.name == 'sRGB'
 
         if channels == 3:
             if use_srgb:
@@ -1251,7 +1250,7 @@ def export_gltf(scene_delta, settings={}):
         'scenes': export_scenes(settings, scenes),
         'shaders': shaders,
         'techniques': techniques,
-        'textures': export_textures(scene_delta.get('textures', []), settings['images_allow_srgb']),
+        'textures': export_textures(scene_delta.get('textures', []), settings),
 
         # TODO
         'animations': {},

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -408,24 +408,33 @@ def export_materials(settings, materials, shaders, programs, techniques):
             technique = 'LAMBERT'
         elif material.specular_shader == 'BLINN':
             technique = 'BLINN'
-        return {
-                'extensions': {
-                    'KHR_materials_common': {
-                        'technique': technique,
-                        'values': {
-                            'ambient': ([material.ambient]*3) + [1.0],
-                            'diffuse': diffuse_textures[-1] if diffuse_textures else diffuse_color,
-                            'doubleSided': not material.game_settings.use_backface_culling,
-                            'emission': emission_textures[-1] if emission_textures else emission_color,
-                            'specular': specular_textures[-1] if specular_textures else specular_color,
-                            'shininess': material.specular_hardness,
-                            'transparency': material.alpha,
-                            'transparent': material.use_transparency,
-                        }
+        gltfmat = {
+            'extensions': {
+                'KHR_materials_common': {
+                    'technique': technique,
+                    'values': {
+                        'ambient': ([material.ambient]*3) + [1.0],
+                        'doubleSided': not material.game_settings.use_backface_culling,
+                        'transparency': material.alpha,
+                        'transparent': material.use_transparency,
                     }
-                },
-                'name': material.name,
-            }
+                }
+            },
+            'name': material.name,
+        }
+
+        vals = gltfmat['extensions']['KHR_materials_common']['values']
+        if technique == 'CONSTANT':
+            vals['emission'] = diffuse_textures[-1] if diffuse_textures else diffuse_color
+        else:
+            vals['emission'] = emission_textures[-1] if emission_textures else emission_color
+            vals['diffuse'] = diffuse_textures[-1] if diffuse_textures else diffuse_color
+            if technique in ['BLINN', 'PHONG']:
+                vals['specular'] = specular_textures[-1] if specular_textures else specular_color
+                vals['shininess'] = material.specular_hardness
+
+        return gltfmat
+
     exp_materials = {}
     for material in materials:
         if settings['shaders_data_storage'] == 'NONE':

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -408,33 +408,24 @@ def export_materials(settings, materials, shaders, programs, techniques):
             technique = 'LAMBERT'
         elif material.specular_shader == 'BLINN':
             technique = 'BLINN'
-        gltfmat = {
-            'extensions': {
-                'KHR_materials_common': {
-                    'technique': technique,
-                    'values': {
-                        'ambient': ([material.ambient]*3) + [1.0],
-                        'doubleSided': not material.game_settings.use_backface_culling,
-                        'transparency': material.alpha,
-                        'transparent': material.use_transparency,
+        return {
+                'extensions': {
+                    'KHR_materials_common': {
+                        'technique': technique,
+                        'values': {
+                            'ambient': ([material.ambient]*3) + [1.0],
+                            'diffuse': diffuse_textures[-1] if diffuse_textures else diffuse_color,
+                            'doubleSided': not material.game_settings.use_backface_culling,
+                            'emission': emission_textures[-1] if emission_textures else emission_color,
+                            'specular': specular_textures[-1] if specular_textures else specular_color,
+                            'shininess': material.specular_hardness,
+                            'transparency': material.alpha,
+                            'transparent': material.use_transparency,
+                        }
                     }
-                }
-            },
-            'name': material.name,
-        }
-
-        vals = gltfmat['extensions']['KHR_materials_common']['values']
-        if technique == 'CONSTANT':
-            vals['emission'] = diffuse_textures[-1] if diffuse_textures else diffuse_color
-        else:
-            vals['emission'] = emission_textures[-1] if emission_textures else emission_color
-            vals['diffuse'] = diffuse_textures[-1] if diffuse_textures else diffuse_color
-            if technique in ['BLINN', 'PHONG']:
-                vals['specular'] = specular_textures[-1] if specular_textures else specular_color
-                vals['shininess'] = material.specular_hardness
-
-        return gltfmat
-
+                },
+                'name': material.name,
+            }
     exp_materials = {}
     for material in materials:
         if settings['shaders_data_storage'] == 'NONE':

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -77,9 +77,18 @@ class Vertex:
         i = loop.index
         self.co = mesh.vertices[vi].co.freeze()
         self.normal = loop.normal.freeze()
-        self.uvs = tuple(layer.data[i].uv.freeze() for layer in mesh.uv_layers)
         self.colors = tuple(layer.data[i].color.freeze() for layer in mesh.vertex_colors)
         self.loop_indices = [i]
+
+        if len(mesh.uv_layers) > 0:
+            ai = mesh.uv_layers.active_index
+            nonactive_layers = mesh.uv_layers[:ai] + mesh.uv_layers[ai+1:]
+            self.uvs = tuple(
+                [mesh.uv_layers.active.data[i].uv.freeze()] +
+                [layer.data[i].uv.freeze() for layer in nonactive_layers]
+            )
+        else:
+            self.uvs = tuple()
 
         # Take the four most influential groups
         groups = sorted(mesh.vertices[vi].groups, key=lambda group: group.weight, reverse=True)

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -27,6 +27,7 @@ default_settings = {
     'asset_profile': 'WEB',
     'ext_export_physics': False,
     'ext_export_actions': False,
+    'images_allow_srgb': True
 }
 
 
@@ -887,7 +888,7 @@ def export_scenes(settings, scenes):
         result = {
             'extras': {
                 'background_color': scene.world.horizon_color[:],
-                'active_camera': scene.camera.name if scene.camera else '',
+                'active_camera': 'camera_'+scene.camera.name if scene.camera else '',
                 'frames_per_second': scene.render.fps,
             },
             'name': scene.name,
@@ -1033,7 +1034,8 @@ def export_textures(textures):
         }
         tformat = None
         channels = texture.image.channels
-        use_srgb = False #texture.image.colorspace_settings.name == 'sRGB'
+        use_srgb = settings['images_allow_srgb'] and
+            texture.image.colorspace_settings.name == 'sRGB'
 
         if channels == 3:
             if use_srgb:

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -396,6 +396,8 @@ def export_materials(settings, materials, shaders, programs, techniques):
         technique = 'PHONG'
         if material.use_shadeless:
             technique = 'CONSTANT'
+            emission_textures = diffuse_textures
+            emission_color = diffuse_color
         elif material.specular_intensity == 0.0:
             technique = 'LAMBERT'
         elif material.specular_shader == 'BLINN':

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -845,7 +845,7 @@ def export_nodes(settings, scenes, objects, skinned_meshes, modded_meshes):
         ob = {
             'name': obj.name,
             'children': ['node_' + child.name for child in obj.children if is_visible(child) and is_selected(child)],
-            'matrix': togl(obj.matrix_world),
+            'matrix': togl(obj.matrix_local),
         }
 
         if obj.type == 'MESH':

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -602,7 +602,7 @@ def export_meshes(settings, meshes, skinned_meshes):
 
             for j, uv in enumerate(vtx.uvs):
                 tdata[j][i * 2] = uv.x
-                tdata[j][i * 2 + 1] = 1 - uv.y
+                tdata[j][i * 2 + 1] = uv.y
 
             for j, col in enumerate(vtx.colors):
                 cdata[j][i * 3] = col[0]

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -77,18 +77,9 @@ class Vertex:
         i = loop.index
         self.co = mesh.vertices[vi].co.freeze()
         self.normal = loop.normal.freeze()
+        self.uvs = tuple(layer.data[i].uv.freeze() for layer in mesh.uv_layers)
         self.colors = tuple(layer.data[i].color.freeze() for layer in mesh.vertex_colors)
         self.loop_indices = [i]
-
-        if len(mesh.uv_layers) > 0:
-            ai = mesh.uv_layers.active_index
-            nonactive_layers = mesh.uv_layers[:ai] + mesh.uv_layers[ai+1:]
-            self.uvs = tuple(
-                [mesh.uv_layers.active.data[i].uv.freeze()] +
-                [layer.data[i].uv.freeze() for layer in nonactive_layers]
-            )
-        else:
-            self.uvs = tuple()
 
         # Take the four most influential groups
         groups = sorted(mesh.vertices[vi].groups, key=lambda group: group.weight, reverse=True)

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -1012,7 +1012,7 @@ def export_images(settings, images):
     return {'image_' + image.name: export_image(image) for image in images if check_image(image)}
 
 
-def export_textures(textures):
+def export_textures(textures, images_allow_srgb):
     def check_texture(texture):
         errors = []
         if texture.image == None:
@@ -1034,8 +1034,7 @@ def export_textures(textures):
         }
         tformat = None
         channels = texture.image.channels
-        use_srgb = settings['images_allow_srgb'] and
-            texture.image.colorspace_settings.name == 'sRGB'
+        use_srgb = images_allow_srgb and texture.image.colorspace_settings.name == 'sRGB'
 
         if channels == 3:
             if use_srgb:
@@ -1250,7 +1249,7 @@ def export_gltf(scene_delta, settings={}):
         'scenes': export_scenes(settings, scenes),
         'shaders': shaders,
         'techniques': techniques,
-        'textures': export_textures(scene_delta.get('textures', [])),
+        'textures': export_textures(scene_delta.get('textures', []), settings['images_allow_srgb']),
 
         # TODO
         'animations': {},

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -617,7 +617,7 @@ def export_meshes(settings, meshes, skinned_meshes):
 
             for j, uv in enumerate(vtx.uvs):
                 tdata[j][i * 2] = uv.x
-                tdata[j][i * 2 + 1] = uv.y
+                tdata[j][i * 2 + 1] = 1 - uv.y
 
             for j, col in enumerate(vtx.colors):
                 cdata[j][i * 3] = col[0]
@@ -1047,11 +1047,11 @@ def export_textures(textures):
     def export_texture(texture):
         gltf_texture = {
             'sampler' : 'sampler_default',
-            'source' : 'image_' + texture.image.name,
+            'source' : 'image_' + texture.image.name
         }
         tformat = None
         channels = texture.image.channels
-        use_srgb = texture.image.colorspace_settings.name == 'sRGB'
+        use_srgb = False #texture.image.colorspace_settings.name == 'sRGB'
 
         if channels == 3:
             if use_srgb:

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -710,10 +710,10 @@ def export_meshes(settings, meshes, skinned_meshes):
 
     exported_meshes = {}
     for me in meshes:
-        if me.users != 0:
-            gltf_mesh = export_mesh(me)
-            if gltf_mesh != None:
-                exported_meshes.update({'mesh_' + me.name: gltf_mesh})
+        #if me.users != 0:
+        gltf_mesh = export_mesh(me)
+        if gltf_mesh != None:
+            exported_meshes.update({'mesh_' + me.name: gltf_mesh})
     return exported_meshes
 
 
@@ -839,7 +839,7 @@ def export_nodes(settings, scenes, objects, skinned_meshes, modded_meshes):
         elif obj.type == 'LAMP':
             ob['extras'] = {'light': 'node_' + obj.data.name}
         elif obj.type == 'CAMERA':
-            ob['camera'] = obj.data.name
+            ob['camera'] = 'camera_' + obj.data.name
         elif obj.type == 'EMPTY' and obj.dupli_group is not None:
             # Expand dupli-groups
             ob['children'] += ['node_' + i.name for i in obj.dupli_group.objects]


### PR DESCRIPTION
- Fixed modified meshes so they are exported correctly. Previously they would be referenced, but not actually output by `export_meshes`.
- Assigned the active UV layer in blender to `TEXCOORD_0`, followed by the remaining layers. Three.js only loads one layer right now, gotta make sure they use the right one.
- Removed disallowed fields from the various types of KHR common materials according to the [extension spec](https://github.com/KhronosGroup/glTF/tree/master/extensions/Khronos/KHR_materials_common#common-material-shared-properties).
- Disable the sRGB texture format, which is not spec compliant, and not supported by either WebGL or glTF.
- Fix object hierarchies. Child objects need to output their matrix in local space, not world space.
- Fix node camera references. Previous references were not prefixed correctly.

If any of these need to go behind a silent flag, let me know. Idkhow much this would break BRTE.