### PR TITLE
BLENDER_physics: Improve dimension handling

### DIFF
--- a/extension_exporters/blender_physics.py
+++ b/extension_exporters/blender_physics.py
@@ -16,15 +16,10 @@ class BlenderPhysics:
             'mass': body.mass,
             'static': body.type == 'PASSIVE',
             'bounding_box': bounds,
-            'height_axis': 2,
+            'primary_axis': "Z",
         }
 
-        if body.collision_shape == 'SPHERE':
-            physics['radius'] = max(bounds) / 2.0
-        elif body.collision_shape in ('CAPSULE', 'CYLINDER', 'CONE'):
-            physics['radius'] = max(bounds[0], bounds[1]) / 2.0
-            physics['height'] = bounds[2]
-        elif body.collision_shape in ('CONVEX_HULL', 'MESH'):
+        if body.collision_shape in ('CONVEX_HULL', 'MESH'):
             physics['mesh'] = 'mesh_' + obj.data.name
 
         return physics

--- a/extensions/BLENDER_physics/README.md
+++ b/extensions/BLENDER_physics/README.md
@@ -12,7 +12,7 @@ Draft
 
 ## Dependencies
 
-Written against the glTF 1.0 and 2.0 draftspec.
+Written against glTF 1.0 and 2.0 specs.
 The only difference for this extension for 1.0 vs 2.0 is the `mesh-id`.
 
 ## Overview
@@ -31,29 +31,74 @@ The properties available are listed in the table below.
 |**collisionShape**|`string`|The shape a physics simulation should use to represent the node|No, default: `BOX`|
 |**mass**|`number`|The 'weight', irrespective of gravity, of the node|No, default: `1.0`|
 |**static**|`boolean`|Specifies if the Node should not be moved by physics simulations|No, default: `false`|
-|**dimensions**|`array`|The bounding box dimensions of the node (x, y, z)|Yes|
+|**bounding_box**|`array`|The bounding box dimensions of the node (x, y, z). Note: this is a local bounding box and does not take the node's transform into account.|Yes|
+|**radius**|`number`|Radius to use for calculating the physics shape. This is based on the dimensions of the bounding box. Note: not all shapes (e.g., `BOX`) make use of this field.|No, default: `0.0`|
+|**height**|`number`|Height to use for calculating the physics shape. This is based on the dimensions of the bounding box. Note: not all shapes (e.g., `BOX`) make use of this field.|No, default: `0.0`|
+|**height_axis**|`number`|Specifies which index of the bounding box (i.e., which axis) is the height (assuming the shape has a height)|No, default: `1`|
 |**mesh**|`glTF id`|The ID of the mesh to use for `CONVEX_HULL` and `MESH` collision shapes|No, default: `node's mesh` if it exists, otherwise use `BOX` shape|
+|**offset_matrix**|`array`|A 4x4 transform matrix applied to the physics shape in addition to the node's transform|No, default: `[ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ]`|
+|**offset_rotation**|`array`|A rotation offset (as a quaternion) applied to the physics shape in addition to the node's rotation|No, default: `[0.0, 0.0, 0.0, 1.0]`|
+|**offset_scale**|`array`|A non-uniform scale offset applied to the physics shape in addition to the node's scale|No, default: `[1.0, 1.0, 1.0]`|
+|**offset_translation**|`array`|A translation offset applied to the physics shape in addition to the node's translation|No, default: `[0.0, 0.0, 0.0]`|
 
 **Collision Shapes**
 
-Below are the allowed values for `collisionShape` along with examples of how to extract shape information from the dimensions (assuming Z-Up).
+Below are the allowed values for `collisionShape`:
 
-* `BOX` - use dimensions as supplied
-* `SPHERE` - radius is `max(dimensions) / 2.0`
-* `CAPSULE` - radius is `max(dimensions[0], dimensions[1]) / 2.0`, height is `dimensions[2] - 2.0 * radius`
-* `CYLINDER` - radius is `max(dimensions[0], dimensions[1]) / 2.0`, height is `dimensions[2]`
-* `CONE` - radius is `max(dimensions[0], dimensions[1]) / 2.0`, height is `dimensions[2]`
-* `CONVEX_HULL` - use mesh
-* `MESH` - use mesh
+* `BOX`
+* `SPHERE`
+* `CAPSULE`
+* `CYLINDER`
+* `CONE`
+* `CONVEX_HULL`
+* `MESH`
 
 **Example**
 
-Below is an example `node` with physics information defined.
+Below are two example nodes with physics information defined.
+The first has a `CAPSULE` shape, and the second has a `MESH` shape.
 Replace `<glTF id>` with the value appropriate for the spec version.
 
 ```javascript
 {
-    "children": [],
+    "extensions": {
+        "BLENDER_physics": {
+            "bounding_box": [
+                2.0000009536743164,
+                2.0000009536743164,
+                4.323975563049316
+            ],
+            "collisionShape": "CAPSULE",
+            "height": 4.323975563049316,
+            "height_axis": 2,
+            "mass": 1.0,
+            "radius": 1.0000004768371582,
+            "static": false
+        }
+    },
+    "mesh": 0,
+    "name": "Cube",
+    "rotation": [
+        0.0,
+        0.0,
+        0.0,
+        1.0
+    ],
+    "scale": [
+        1.0,
+        1.0,
+        1.0
+    ],
+    "translation": [
+        -3.725290298461914e-08,
+        -2.9802322387695312e-08,
+        1.1619879007339478
+    ]
+}
+```
+
+```javascript
+{
     "extensions": {
         "BLENDER_physics": {
             "collisionShape": "MESH",

--- a/extensions/BLENDER_physics/README.md
+++ b/extensions/BLENDER_physics/README.md
@@ -30,20 +30,20 @@ The properties available are listed in the table below.
 |---|----|-----------|--------|
 |**collisionShape**|`string`|The shape a physics simulation should use to represent the node|No, default: `BOX`|
 |**mass**|`number`|The 'weight', irrespective of gravity, of the node|No, default: `1.0`|
-|**static**|`boolean`|Specifies if the Node should not be moved by physics simulations|No, default: `false`|
-|**bounding_box**|`array`|The bounding box dimensions of the node (x, y, z). Note: this is a local bounding box and does not take the node's transform into account.|Yes|
-|**radius**|`number`|Radius to use for calculating the physics shape. This is based on the dimensions of the bounding box. Note: not all shapes (e.g., `BOX`) make use of this field.|No, default: `0.0`|
-|**height**|`number`|Height to use for calculating the physics shape. This is based on the dimensions of the bounding box. Note: not all shapes (e.g., `BOX`) make use of this field.|No, default: `0.0`|
-|**height_axis**|`number`|Specifies which index of the bounding box (i.e., which axis) is the height (assuming the shape has a height)|No, default: `1`|
+|**static**|`boolean`|Whether or not the Node should be moved by physics simulations|No, default: `false`|
+|**bounding_box**|`array`|The dimensions of the local (i.e., does not include the node's transform) bounding box of the collision shape centered on the origin|Yes|
+|**primary_axis**|`number`|The axis to use for the height of the collision shape|No, default: `1`|
 |**mesh**|`glTF id`|The ID of the mesh to use for `CONVEX_HULL` and `MESH` collision shapes|No, default: `node's mesh` if it exists, otherwise use `BOX` shape|
-|**offset_matrix**|`array`|A 4x4 transform matrix applied to the physics shape in addition to the node's transform|No, default: `[ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ]`|
+|**offset_matrix**|`array`|A 4x4 transform matrix applied to the collision shape in addition to the node's transform|No, default: `[ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ]`|
 |**offset_rotation**|`array`|A rotation offset (as a quaternion) applied to the physics shape in addition to the node's rotation|No, default: `[0.0, 0.0, 0.0, 1.0]`|
-|**offset_scale**|`array`|A non-uniform scale offset applied to the physics shape in addition to the node's scale|No, default: `[1.0, 1.0, 1.0]`|
-|**offset_translation**|`array`|A translation offset applied to the physics shape in addition to the node's translation|No, default: `[0.0, 0.0, 0.0]`|
+|**offset_scale**|`array`|A non-uniform scale offset applied to the collision shape in addition to the node's scale|No, default: `[1.0, 1.0, 1.0]`|
+|**offset_translation**|`array`|A translation offset applied to the collision shape in addition to the node's translation|No, default: `[0.0, 0.0, 0.0]`|
 
 **Collision Shapes**
 
-Below are the allowed values for `collisionShape`:
+Below are the allowed values for `collisionShape`.
+When consuming this extension, an application should construct the `collisionShape` with parameters that best fill the `bounding_box`.
+The shape offset should be applied to the shape prior to the node's transform.
 
 * `BOX`
 * `SPHERE`
@@ -69,10 +69,8 @@ Replace `<glTF id>` with the value appropriate for the spec version.
                 4.323975563049316
             ],
             "collisionShape": "CAPSULE",
-            "height": 4.323975563049316,
-            "height_axis": 2,
+            "primary_axis": "Z",
             "mass": 1.0,
-            "radius": 1.0000004768371582,
             "static": false
         }
     },
@@ -101,12 +99,13 @@ Replace `<glTF id>` with the value appropriate for the spec version.
 {
     "extensions": {
         "BLENDER_physics": {
-            "collisionShape": "MESH",
-            "dimensions": [
+            "bounding_box": [
                 2.0000009536743164,
                 2.0000009536743164,
                 2.0
             ],
+            "collisionShape": "MESH",
+            "primary_axis": "Z",
             "mass": 1.0,
             "mesh": <glTF id>,
             "static": false

--- a/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
+++ b/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
@@ -25,31 +25,26 @@
             "default": 1.0
         },
         "static" : {
-            "description": "The Node should not be moved by physics simulations",
+            "description": "Whether or not the Node should be moved by physics simulations",
             "type": "boolean",
             "default": false
         },
         "bounding_box" : {
-            "description": "The local bounding box dimensions of the node",
+            "description": "The dimensions of the local (i.e., does not include the node's transform) bounding box of the collision shape centered on the origin",
             "type": "array",
             "items": {"type": "number"},
             "minItems": 3,
             "maxItems": 3
         },
-        "radius" : {
-            "description": "Radius to use for calculating the physics shape based on bounding box of the node",
-            "type": "number",
-            "default": 0.0
-        },
-        "height" : {
-            "description": "Height to use for calculating the physics shape based on bounding box of the node",
-            "type": "number",
-            "default": 0.0
-        },
-        "height_axis" : {
-            "description": "The axis (0=X, 1=Y, 2=Z) to use for the height of the node",
-            "type": "number",
-            "default": 1
+        "primary_axis" : {
+            "description": "The axis to use for the height of the collision shape",
+            "type": "string",
+            "enum": [
+                "X",
+                "Y",
+                "Z"
+            ],
+            "default": "Y"
         },
         "mesh" : {
             "description": "The ID of the mesh to use for CONVEX_HULL and MESH collision shapes",
@@ -57,7 +52,7 @@
         },
         "offset_matrix": {
             "type": "array",
-            "description": "A 4x4 transform matrix applied to the physics shape in addition to the node's transform",
+            "description": "A 4x4 transform matrix applied to the collision shape in addition to the node's transform",
             "items": {
                 "type": "number"
             },
@@ -67,7 +62,7 @@
         },
         "offset_rotation": {
             "type": "array",
-            "description": "A rotation offset (as a quaternion) applied to the physics shape in addition to the node's rotation",
+            "description": "A rotation offset (as a quaternion) applied to the collision shape in addition to the node's rotation",
             "items": {
                 "type": "number",
                 "minimum": -1.0,
@@ -79,7 +74,7 @@
         },
         "offset_scale": {
             "type": "array",
-            "description": "A non-uniform scale offset applied to the physics shape in addition to the node's scale",
+            "description": "A non-uniform scale offset applied to the collision shape in addition to the node's scale",
             "items": {
                 "type": "number"
             },
@@ -89,7 +84,7 @@
         },
         "offset_translation": {
             "type": "array",
-            "description": "A translation offset applied to the physics shape in addition to the node's translation",
+            "description": "A translation offset applied to the collision shape in addition to the node's translation",
             "items": {
                 "type": "number"
             },

--- a/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
+++ b/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
@@ -29,16 +29,73 @@
             "type": "boolean",
             "default": false
         },
-        "dimensions" : {
-            "description": "The bounding box dimensions of the node",
+        "bounding_box" : {
+            "description": "The local bounding box dimensions of the node",
             "type": "array",
             "items": {"type": "number"},
             "minItems": 3,
             "maxItems": 3
         },
-        "mesh": {
+        "radius" : {
+            "description": "Radius to use for calculating the physics shape based on bounding box of the node",
+            "type": "number",
+            "default": 0.0
+        },
+        "height" : {
+            "description": "Height to use for calculating the physics shape based on bounding box of the node",
+            "type": "number",
+            "default": 0.0
+        },
+        "height_axis" : {
+            "description": "The axis (0=X, 1=Y, 2=Z) to use for the height of the node",
+            "type": "number",
+            "default": 1
+        },
+        "mesh" : {
             "description": "The ID of the mesh to use for CONVEX_HULL and MESH collision shapes",
             "allOf": [{"$ref": "glTFid.schema.json"}]
+        },
+        "offset_matrix": {
+            "type": "array",
+            "description": "A 4x4 transform matrix applied to the physics shape in addition to the node's transform",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 16,
+            "maxItems": 16,
+            "default": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ]
+        },
+        "offset_rotation": {
+            "type": "array",
+            "description": "A rotation offset (as a quaternion) applied to the physics shape in addition to the node's rotation",
+            "items": {
+                "type": "number",
+                "minimum": -1.0,
+                "maximum": 1.0
+            },
+            "minItems": 4,
+            "maxItems": 4,
+            "default": [ 0.0, 0.0, 0.0, 1.0 ]
+        },
+        "offset_scale": {
+            "type": "array",
+            "description": "A non-uniform scale offset applied to the physics shape in addition to the node's scale",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "default": [ 1.0, 1.0, 1.0 ]
+        },
+        "offset_translation": {
+            "type": "array",
+            "description": "A translation offset applied to the physics shape in addition to the node's translation",
+            "items": {
+                "type": "number"
+            },
+            "minItems": 3,
+            "maxItems": 3,
+            "default": [ 0.0, 0.0, 0.0 ]
         }
     },
     "additionalProperties" : false,


### PR DESCRIPTION
We now export radius and height instead of forcing importers to extract
this information from dimensions. Dimensions (now exported as
bounding_box) no longer have scale applied and are strictly local
bounding boxes (i.e., it does not take the node's transform into
account). A transform offset can now also be supplied.