### PR TITLE
Added gltf basename as prefix to buffer

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -319,6 +319,8 @@ class ExportGLTF(bpy.types.Operator, ExportHelper, GLTFOrientationHelper):
 
         # Set the output directory based on the supplied file path
         settings['gltf_output_dir'] = os.path.dirname(self.filepath)
+        settings['gltf_name'] = os.path.splitext(os.path.basename(self.filepath))[0]
+        
 
         # Calculate a global transform matrix to apply to a root node
         settings['nodes_global_matrix'] = axis_conversion(

--- a/blendergltf.py
+++ b/blendergltf.py
@@ -282,6 +282,7 @@ class Buffer:
             uri = 'data:application/octet-stream;base64,' + base64.b64encode(data).decode('ascii')
         else:
             uri = bpy.path.clean_name(self.name) + '.bin'
+            uri = '{}_{}.bin'.format(state['settings']['gltf_name'], bpy.path.clean_name(self.name))
             with open(os.path.join(state['settings']['gltf_output_dir'], uri), 'wb') as fout:
                 fout.write(data)
 


### PR DESCRIPTION
This prevents the buffer from overwriting different exports in the same folder. (See https://github.com/Kupoman/blendergltf/issues/64 for example)