### PR TITLE
Add "intangible" flag for collision nodes

### DIFF
--- a/extensions/BLENDER_physics/README.md
+++ b/extensions/BLENDER_physics/README.md
@@ -31,6 +31,7 @@ The properties available are listed in the table below.
 |**collisionShapes**|`array`|Shapes a simulation should use to represent the node|Yes|
 |**mass**|`number`|The 'weight', irrespective of gravity, of the node|No, default: `1.0`|
 |**static**|`boolean`|Whether or not the Node should be moved by physics simulations|No, default: `false`|
+|**intangible**|`boolean`|Whether or not the Node should stop another object from passing through|No, default: `false`|
 |**collisionGroups**|`integer`|A 32-bit bit field representing the node's group membership|No, default: `1`|
 |**collisionMasks**|`integer`|A 32-bit bit field representing what groups the node can collide with|No, default: `1`|
 

--- a/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
+++ b/extensions/BLENDER_physics/schema/node.BLENDER_physics.schema.json
@@ -10,7 +10,7 @@
             "type": "array",
             "items": {
                 "$ref": "node.BLENDER_physics.shape.schema.json"
-            }
+            },
             "minItems": 1
         },
         "mass" : {
@@ -20,6 +20,11 @@
         },
         "static" : {
             "description": "Whether or not the Node should be moved by physics simulations",
+            "type": "boolean",
+            "default": false
+        },
+        "intangible" : {
+            "description": "Whether or not the Node should stop another object from passing through",
             "type": "boolean",
             "default": false
         },


### PR DESCRIPTION
This flag could be used to mark node as "intangible" allowing another objects to pass through. Those objects could trigger events when they intersect with another objects.